### PR TITLE
Fixing updated xajaxResponse function names in Issue #7

### DIFF
--- a/rack_maint.inc.php
+++ b/rack_maint.inc.php
@@ -128,7 +128,7 @@ function ws_display_list($window_name, $form) {
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getOutput());
+        return($response->printOutput());
     }
 
     // If the group supplied an array in a string, build the array and store it in $form
@@ -258,7 +258,7 @@ EOL;
     $response->assign("{$form['form_id']}_racks_count",  "innerHTML", "({$count})");
     $response->assign("{$form['content_id']}", "innerHTML", $html);
     // $response->addScript($js);
-    return($response->getOutput());
+    return($response->printOutput());
 }
 
 
@@ -1286,7 +1286,7 @@ function ws_rack_editor($window_name, $form='') {
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getOutput());
+        return($response->printOutput());
     }
 
     // If the user supplied an array in a string, build the array and store it in $form
@@ -1469,7 +1469,7 @@ function ws_ru_editor($window_name, $form='') {
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getOutput());
+        return($response->printOutput());
     }
 
     // If the user supplied an array in a string, build the array and store it in $form
@@ -1697,7 +1697,7 @@ function ws_rack_save($window_name, $form='') {
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getOutput());
+        return($response->printOutput());
     }
 
     // Instantiate the xajaxResponse object
@@ -1734,7 +1734,7 @@ function ws_rack_save($window_name, $form='') {
 
     // Insert the new table into the window
     $response->addScript($js);
-    return($response->getOutput());
+    return($response->printOutput());
 }
 
 
@@ -1759,7 +1759,7 @@ function ws_save($window_name, $form='') {
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getOutput());
+        return($response->printOutput());
     }
 
     // Instantiate the xajaxResponse object
@@ -1797,7 +1797,7 @@ function ws_save($window_name, $form='') {
 
     // Insert the new table into the window
     $response->addScript($js);
-    return($response->getOutput());
+    return($response->printOutput());
 }
 
 
@@ -1820,7 +1820,7 @@ function ws_rack_delete($window_name, $form='') {
     if (! (auth('rack_del') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getOutput());
+        return($response->printOutput());
     }
 
     // If an array in a string was provided, build the array and store it in $form
@@ -1844,7 +1844,7 @@ function ws_rack_delete($window_name, $form='') {
 
     // Return an XML response
     $response->addScript($js);
-    return($response->getOutput());
+    return($response->printOutput());
 }
 
 
@@ -1869,7 +1869,7 @@ function ws_delete($window_name, $form='') {
     if (! (auth('rack_del') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getOutput());
+        return($response->printOutput());
     }
 
     // If an array in a string was provided, build the array and store it in $form
@@ -1893,7 +1893,7 @@ function ws_delete($window_name, $form='') {
 
     // Return an XML response
     $response->addScript($js);
-    return($response->getOutput());
+    return($response->printOutput());
 }
 
 
@@ -1933,7 +1933,7 @@ EOL;
     $response = new xajaxResponse();
     $response->assign("rack_unit_info", "innerHTML", $html);
     if ($js) { $response->addScript($js); }
-    return($response->getOutput());
+    return($response->printOutput());
 
 }*/
 
@@ -2042,7 +2042,7 @@ function ws_display($window_name, $form='') {
         $html .= "<br><center><font color=\"red\"><b>Rack doesn't exist!</b></font></center>";
         $response = new xajaxResponse();
         $response->assign("work_space_content", "innerHTML", $html);
-        return($response->getOutput());
+        return($response->printOutput());
     }
 
     // get location info
@@ -2463,7 +2463,7 @@ EOL;
     $response = new xajaxResponse();
     $response->assign("work_space_content", "innerHTML", $html);
     if ($js) { $response->addScript($js); }
-    return($response->getOutput());
+    return($response->printOutput());
 }
 
 

--- a/rack_maint.inc.php
+++ b/rack_maint.inc.php
@@ -255,8 +255,8 @@ EOL;
     // Insert the new table into the window
     // Instantiate the xajaxResponse object
     $response = new xajaxResponse();
-    $response->addAssign("{$form['form_id']}_racks_count",  "innerHTML", "({$count})");
-    $response->addAssign("{$form['content_id']}", "innerHTML", $html);
+    $response->assign("{$form['form_id']}_racks_count",  "innerHTML", "({$count})");
+    $response->assign("{$form['content_id']}", "innerHTML", $html);
     // $response->addScript($js);
     return($response->getXML());
 }
@@ -1931,7 +1931,7 @@ EOL;
     // Insert the new html into the window
     // Instantiate the xajaxResponse object
     $response = new xajaxResponse();
-    $response->addAssign("rack_unit_info", "innerHTML", $html);
+    $response->assign("rack_unit_info", "innerHTML", $html);
     if ($js) { $response->addScript($js); }
     return($response->getXML());
 
@@ -2041,7 +2041,7 @@ function ws_display($window_name, $form='') {
         array_pop($_SESSION['ona']['work_space']['history']);
         $html .= "<br><center><font color=\"red\"><b>Rack doesn't exist!</b></font></center>";
         $response = new xajaxResponse();
-        $response->addAssign("work_space_content", "innerHTML", $html);
+        $response->assign("work_space_content", "innerHTML", $html);
         return($response->getXML());
     }
 
@@ -2461,7 +2461,7 @@ EOL;
     // Insert the new html into the window
     // Instantiate the xajaxResponse object
     $response = new xajaxResponse();
-    $response->addAssign("work_space_content", "innerHTML", $html);
+    $response->assign("work_space_content", "innerHTML", $html);
     if ($js) { $response->addScript($js); }
     return($response->getXML());
 }

--- a/rack_maint.inc.php
+++ b/rack_maint.inc.php
@@ -127,7 +127,7 @@ function ws_display_list($window_name, $form) {
     // Check permissions
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
-        $response->addScript("alert('Permission denied!');");
+        $response->includeScript("alert('Permission denied!');");
         return($response->printOutput());
     }
 
@@ -257,7 +257,7 @@ EOL;
     $response = new xajaxResponse();
     $response->assign("{$form['form_id']}_racks_count",  "innerHTML", "({$count})");
     $response->assign("{$form['content_id']}", "innerHTML", $html);
-    // $response->addScript($js);
+    // $response->includeScript($js);
     return($response->printOutput());
 }
 
@@ -1285,7 +1285,7 @@ function ws_rack_editor($window_name, $form='') {
     // Check permissions
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
-        $response->addScript("alert('Permission denied!');");
+        $response->includeScript("alert('Permission denied!');");
         return($response->printOutput());
     }
 
@@ -1468,7 +1468,7 @@ function ws_ru_editor($window_name, $form='') {
     // Check permissions
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
-        $response->addScript("alert('Permission denied!');");
+        $response->includeScript("alert('Permission denied!');");
         return($response->printOutput());
     }
 
@@ -1696,7 +1696,7 @@ function ws_rack_save($window_name, $form='') {
     // Check permissions
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
-        $response->addScript("alert('Permission denied!');");
+        $response->includeScript("alert('Permission denied!');");
         return($response->printOutput());
     }
 
@@ -1733,7 +1733,7 @@ function ws_rack_save($window_name, $form='') {
     }
 
     // Insert the new table into the window
-    $response->addScript($js);
+    $response->includeScript($js);
     return($response->printOutput());
 }
 
@@ -1758,7 +1758,7 @@ function ws_save($window_name, $form='') {
     // Check permissions
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
-        $response->addScript("alert('Permission denied!');");
+        $response->includeScript("alert('Permission denied!');");
         return($response->printOutput());
     }
 
@@ -1796,7 +1796,7 @@ function ws_save($window_name, $form='') {
     }
 
     // Insert the new table into the window
-    $response->addScript($js);
+    $response->includeScript($js);
     return($response->printOutput());
 }
 
@@ -1819,7 +1819,7 @@ function ws_rack_delete($window_name, $form='') {
     // Check permissions
     if (! (auth('rack_del') or auth('advanced'))){
         $response = new xajaxResponse();
-        $response->addScript("alert('Permission denied!');");
+        $response->includeScript("alert('Permission denied!');");
         return($response->printOutput());
     }
 
@@ -1843,7 +1843,7 @@ function ws_rack_delete($window_name, $form='') {
         $js .= $form['js'];  // usually js will refresh the window we got called from
 
     // Return an XML response
-    $response->addScript($js);
+    $response->includeScript($js);
     return($response->printOutput());
 }
 
@@ -1868,7 +1868,7 @@ function ws_delete($window_name, $form='') {
     // Check permissions
     if (! (auth('rack_del') or auth('advanced'))){
         $response = new xajaxResponse();
-        $response->addScript("alert('Permission denied!');");
+        $response->includeScript("alert('Permission denied!');");
         return($response->printOutput());
     }
 
@@ -1892,7 +1892,7 @@ function ws_delete($window_name, $form='') {
         $js .= $form['js'];  // usually js will refresh the window we got called from
 
     // Return an XML response
-    $response->addScript($js);
+    $response->includeScript($js);
     return($response->printOutput());
 }
 
@@ -1932,7 +1932,7 @@ EOL;
     // Instantiate the xajaxResponse object
     $response = new xajaxResponse();
     $response->assign("rack_unit_info", "innerHTML", $html);
-    if ($js) { $response->addScript($js); }
+    if ($js) { $response->includeScript($js); }
     return($response->printOutput());
 
 }*/
@@ -2462,7 +2462,7 @@ EOL;
     // Instantiate the xajaxResponse object
     $response = new xajaxResponse();
     $response->assign("work_space_content", "innerHTML", $html);
-    if ($js) { $response->addScript($js); }
+    if ($js) { $response->includeScript($js); }
     return($response->printOutput());
 }
 

--- a/rack_maint.inc.php
+++ b/rack_maint.inc.php
@@ -128,7 +128,7 @@ function ws_display_list($window_name, $form) {
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getXML());
+        return($response->getOutput());
     }
 
     // If the group supplied an array in a string, build the array and store it in $form
@@ -258,7 +258,7 @@ EOL;
     $response->assign("{$form['form_id']}_racks_count",  "innerHTML", "({$count})");
     $response->assign("{$form['content_id']}", "innerHTML", $html);
     // $response->addScript($js);
-    return($response->getXML());
+    return($response->getOutput());
 }
 
 
@@ -1286,7 +1286,7 @@ function ws_rack_editor($window_name, $form='') {
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getXML());
+        return($response->getOutput());
     }
 
     // If the user supplied an array in a string, build the array and store it in $form
@@ -1469,7 +1469,7 @@ function ws_ru_editor($window_name, $form='') {
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getXML());
+        return($response->getOutput());
     }
 
     // If the user supplied an array in a string, build the array and store it in $form
@@ -1697,7 +1697,7 @@ function ws_rack_save($window_name, $form='') {
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getXML());
+        return($response->getOutput());
     }
 
     // Instantiate the xajaxResponse object
@@ -1734,7 +1734,7 @@ function ws_rack_save($window_name, $form='') {
 
     // Insert the new table into the window
     $response->addScript($js);
-    return($response->getXML());
+    return($response->getOutput());
 }
 
 
@@ -1759,7 +1759,7 @@ function ws_save($window_name, $form='') {
     if (! (auth('rack_add') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getXML());
+        return($response->getOutput());
     }
 
     // Instantiate the xajaxResponse object
@@ -1797,7 +1797,7 @@ function ws_save($window_name, $form='') {
 
     // Insert the new table into the window
     $response->addScript($js);
-    return($response->getXML());
+    return($response->getOutput());
 }
 
 
@@ -1820,7 +1820,7 @@ function ws_rack_delete($window_name, $form='') {
     if (! (auth('rack_del') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getXML());
+        return($response->getOutput());
     }
 
     // If an array in a string was provided, build the array and store it in $form
@@ -1844,7 +1844,7 @@ function ws_rack_delete($window_name, $form='') {
 
     // Return an XML response
     $response->addScript($js);
-    return($response->getXML());
+    return($response->getOutput());
 }
 
 
@@ -1869,7 +1869,7 @@ function ws_delete($window_name, $form='') {
     if (! (auth('rack_del') or auth('advanced'))){
         $response = new xajaxResponse();
         $response->addScript("alert('Permission denied!');");
-        return($response->getXML());
+        return($response->getOutput());
     }
 
     // If an array in a string was provided, build the array and store it in $form
@@ -1893,7 +1893,7 @@ function ws_delete($window_name, $form='') {
 
     // Return an XML response
     $response->addScript($js);
-    return($response->getXML());
+    return($response->getOutput());
 }
 
 
@@ -1933,7 +1933,7 @@ EOL;
     $response = new xajaxResponse();
     $response->assign("rack_unit_info", "innerHTML", $html);
     if ($js) { $response->addScript($js); }
-    return($response->getXML());
+    return($response->getOutput());
 
 }*/
 
@@ -2042,7 +2042,7 @@ function ws_display($window_name, $form='') {
         $html .= "<br><center><font color=\"red\"><b>Rack doesn't exist!</b></font></center>";
         $response = new xajaxResponse();
         $response->assign("work_space_content", "innerHTML", $html);
-        return($response->getXML());
+        return($response->getOutput());
     }
 
     // get location info
@@ -2463,7 +2463,7 @@ EOL;
     $response = new xajaxResponse();
     $response->assign("work_space_content", "innerHTML", $html);
     if ($js) { $response->addScript($js); }
-    return($response->getXML());
+    return($response->getOutput());
 }
 
 


### PR DESCRIPTION
In the xajax update from what is in onav18 to onav19, xajaxResponse function names appear to have changed and the plugin is throwing errors in php8.1 and php8.3 in Issue #7 

addAssign changed to assign
getXML changed to printOutput
addScript changed to includeScript

With these changes the rack_maint plugin seems to be working for me in php8.3 on Ubuntu 24.04.